### PR TITLE
Omniglot resize - Fix image mode for the resample to be effective

### DIFF
--- a/data/omniglot_resized/resize_images.py
+++ b/data/omniglot_resized/resize_images.py
@@ -20,7 +20,7 @@ i = 0
 
 for image_file in all_images:
     im = Image.open(image_file)
-    im = im.resize((28,28), resample=Image.LANCZOS)
+    im = im.convert('L').resize((28,28), resample=Image.LANCZOS)
     im.save(image_file)
     i += 1
 


### PR DESCRIPTION
In the omniglot dataset, images are in black and white mode.
When resizing in that mode, resampling is useless as gray tones are not allowed.
As you specified a resample method, I think that this was not intended